### PR TITLE
Add missing cython requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ ipython==7.8.0
 autopep8==1.5
 arrow==0.15.5
 psycopg2-binary==2.8.4
+cython==0.29.21


### PR DESCRIPTION
This will fix error when running first instruction step: `pip install -r requirements.txt` from JupyterLab env:
```
  ModuleNotFoundError: No module named 'Cython'
```