### PR TITLE
fix: update jenkins to 2.266 version

### DIFF
--- a/Dockerfile-jenkins
+++ b/Dockerfile-jenkins
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.252-slim
+FROM jenkins/jenkins:2.266-slim
 
 USER jenkins
 RUN /usr/local/bin/install-plugins.sh blueocean:1.23.2 build-timestamp:1.0.3 timestamper:1.11.2 pollscm:1.3.1 github-api:1.115


### PR DESCRIPTION
Currently to run the project is necessary to use the latest version of jenkinks available (2,266). There are two ways to update it, manually or by uploading the version in its corresponding dockerfile. This pull request opts for the second option, now the jenkins image is "jenkins/jenkins:2.266-slim".

This pull request facilitates the update of jenkins to run the workshop without issues.