### PR TITLE
fix: update github-api-plugin to 1.122

### DIFF
--- a/Dockerfile-jenkins
+++ b/Dockerfile-jenkins
@@ -1,7 +1,7 @@
 FROM jenkins/jenkins:2.266-slim
 
 USER jenkins
-RUN /usr/local/bin/install-plugins.sh blueocean:1.23.2 build-timestamp:1.0.3 timestamper:1.11.2 pollscm:1.3.1 github-api:1.115
+RUN /usr/local/bin/install-plugins.sh blueocean:1.23.2 build-timestamp:1.0.3 timestamper:1.11.2 pollscm:1.3.1 github-api:1.122
 
 USER root
 ENV FLUENTD_HOST "fluentd"


### PR DESCRIPTION
Currently to run the project is necessary to use the latest version of github-api-plugin available (1.122).

This pull request facilitates the update of github-api-plugin to run the workshop without issues.