### PR TITLE
Adjust GitHub API version in Jenkins Dockerfile

### DIFF
--- a/Dockerfile-jenkins
+++ b/Dockerfile-jenkins
@@ -1,7 +1,7 @@
 FROM jenkins/jenkins:2.266-slim
 
 USER jenkins
-RUN /usr/local/bin/install-plugins.sh blueocean:1.23.2 build-timestamp:1.0.3 timestamper:1.11.2 pollscm:1.3.1 github-api:1.115
+RUN /usr/local/bin/install-plugins.sh blueocean:1.23.2 build-timestamp:1.0.3 timestamper:1.11.2 pollscm:1.3.1 github-api:1.122
 
 USER root
 ENV FLUENTD_HOST "fluentd"


### PR DESCRIPTION
Change to GitHub API version 1.122 due to the fact that the given version no longer works with GitHub.