### PR TITLE
Update jenkins image to an image for intel and arm platforms

### DIFF
--- a/Dockerfile-jenkins
+++ b/Dockerfile-jenkins
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.347-slim
+FROM jenkins/jenkins:2.347-jdk11
 
 USER jenkins
 RUN /usr/local/bin/install-plugins.sh blueocean:1.25.5 build-timestamp:1.0.3 timestamper:1.17 pollscm:1.3.1 github-api:1.303-400.v35c2d8258028


### PR DESCRIPTION
Update jenkins update to an image for both intel (amd64) and M1/ARM (arm64).